### PR TITLE
Fixed ModelLoader Cache

### DIFF
--- a/src/Charcoal/Model/Service/ModelLoaderBuilder.php
+++ b/src/Charcoal/Model/Service/ModelLoaderBuilder.php
@@ -2,10 +2,14 @@
 
 namespace Charcoal\Model\Service;
 
-// Module `charcoal-factory` dependencies
-use \Charcoal\Factory\FactoryInterface;
+// From PSR-6
+use Psr\Cache\CacheItemPoolInterface;
 
-use \Charcoal\Model\Service\ModelLoader;
+// From 'charcoal-factory'
+use Charcoal\Factory\FactoryInterface;
+
+// From 'charcoal-core'
+use Charcoal\Model\Service\ModelLoader;
 
 /**
  * Model Loader Builder.
@@ -20,11 +24,17 @@ final class ModelLoaderBuilder
     private $factory;
 
     /**
-     * @param array $data The constructor options (factory).
+     * @var CacheItemPoolInterface
+     */
+    private $cachePool;
+
+    /**
+     * @param array $data Builder dependencies.
      */
     public function __construct(array $data)
     {
         $this->setFactory($data['factory']);
+        $this->setCachePool($data['cache']);
     }
 
     /**
@@ -35,7 +45,8 @@ final class ModelLoaderBuilder
     public function build($objType, $objKey = null)
     {
         return new ModelLoader([
-            'factory' => $this->factory,
+            'factory'   => $this->factory,
+            'cache'     => $this->cachePool,
             'obj_type'  => $objType,
             'obj_key'   => $objKey
         ]);
@@ -60,6 +71,18 @@ final class ModelLoaderBuilder
     private function setFactory(FactoryInterface $factory)
     {
         $this->factory = $factory;
+
+        return $this;
+    }
+
+    /**
+     * @param CacheItemPoolInterface $cachePool The PSR-6 compliant cache pool.
+     * @return ModelLoaderBuilder Chainable
+     */
+    private function setCachePool(CacheItemPoolInterface $cachePool)
+    {
+        $this->cachePool = $cachePool;
+
         return $this;
     }
 }

--- a/tests/Charcoal/Model/Service/ModelLoaderTest.php
+++ b/tests/Charcoal/Model/Service/ModelLoaderTest.php
@@ -2,10 +2,11 @@
 
 namespace Charcoal\Tests\Model\Service;
 
-use \Charcoal\Factory\GenericFactory as Factory;
+// From 'charcoal-factory'
+use Charcoal\Factory\GenericFactory as Factory;
 
-use \Charcoal\Model\Service\MetadataLoader;
-use \Charcoal\Model\Service\ModelLoader;
+// From 'charcoal-core'
+use Charcoal\Model\Service\ModelLoader;
 
 /**
  *
@@ -14,30 +15,32 @@ class ModelLoaderTest extends \PHPUnit_Framework_TestCase
 {
     use \Charcoal\Tests\ContainerIntegrationTrait;
 
+    /**
+     * Tested Class.
+     *
+     * @var ModelLoader
+     */
     public $obj;
 
+    /**
+     * Set up the test.
+     */
     public function setUp()
     {
         $container = $this->getContainer();
 
-        $metadataLoader = new MetadataLoader([
-            'logger'    => $container['logger'],
-            'cache'     => $container['cache'],
-            'base_path' => __DIR__,
-            'paths'     => [ 'metadata' ]
-        ]);
-
         $factory = new Factory([
             'arguments' => [[
                 'logger'          => $container['logger'],
-                'metadata_loader' => $metadataLoader
+                'metadata_loader' => $container['metadata/loader']
             ]]
         ]);
 
         $this->obj = new ModelLoader([
             'obj_type' => 'charcoal/model/model',
             'factory'  => $factory,
-            'logger'   => $container['logger']
+            'logger'   => $container['logger'],
+            'cache'    => $container['cache']
         ]);
     }
 


### PR DESCRIPTION
This reverts commit 61d0cc8 and alters the caching mechanism to store the object data instead of the instance. This prevents issues when unserializing a class that might have dependencies.