### PR TITLE
Add support for nested Filter Expressions

### DIFF
--- a/src/Charcoal/Source/AbstractSource.php
+++ b/src/Charcoal/Source/AbstractSource.php
@@ -2,7 +2,6 @@
 
 namespace Charcoal\Source;
 
-use RuntimeException;
 use InvalidArgumentException;
 
 // From PSR-3
@@ -17,10 +16,9 @@ use Charcoal\Config\ConfigurableTrait;
 use Charcoal\Property\PropertyInterface;
 
 // From 'charcoal-core'
-use Charcoal\Model\ModelInterface;
-
 use Charcoal\Source\SourceConfig;
 use Charcoal\Source\SourceInterface;
+use Charcoal\Source\ModelAwareTrait;
 use Charcoal\Source\Filter;
 use Charcoal\Source\FilterInterface;
 use Charcoal\Source\FilterCollectionTrait;
@@ -40,19 +38,13 @@ abstract class AbstractSource implements
 {
     use ConfigurableTrait;
     use LoggerAwareTrait;
+    use ModelAwareTrait;
     use FilterCollectionTrait {
         FilterCollectionTrait::addFilter as pushFilter;
     }
     use OrderCollectionTrait {
         OrderCollectionTrait::addOrder as pushOrder;
     }
-
-    /**
-     * The related model.
-     *
-     * @var ModelInterface
-     */
-    private $model;
 
     /**
      * The {@see self::$model}'s properties.
@@ -113,44 +105,6 @@ abstract class AbstractSource implements
         }
 
         return $this;
-    }
-
-    /**
-     * Set the source's Model.
-     *
-     * @param  ModelInterface $model The source's model.
-     * @return self
-     */
-    public function setModel(ModelInterface $model)
-    {
-        $this->model = $model;
-        return $this;
-    }
-
-    /**
-     * Determine if a model is assigned.
-     *
-     * @return boolean
-     */
-    public function hasModel()
-    {
-        return !empty($this->model);
-    }
-
-    /**
-     * Return the source's Model.
-     *
-     * @throws RuntimeException If not model was previously set.
-     * @return ModelInterface
-     */
-    public function model()
-    {
-        if ($this->model === null) {
-            throw new RuntimeException(
-                'Model was not set.'
-            );
-        }
-        return $this->model;
     }
 
     /**

--- a/src/Charcoal/Source/DatabaseSource.php
+++ b/src/Charcoal/Source/DatabaseSource.php
@@ -807,37 +807,16 @@ class DatabaseSource extends AbstractSource implements
             return '';
         }
 
-        $parts = [];
-        foreach ($this->filters() as $filter) {
-            if (!$filter instanceof DatabaseFilter) {
-                $filter = $this->createFilter($filter->data());
-            }
+        $criteria = $this->createFilter([
+            'filters' => $this->filters()
+        ]);
 
-            $sql = $filter->sql();
-            if (strlen($sql) > 0) {
-                $parts[] = [
-                    'sql'     => $sql,
-                    'operand' => $filter->operand()
-                ];
-            }
+        $sql = $criteria->sql();
+        if (strlen($sql) > 0) {
+            $sql = ' WHERE '.$sql;
         }
 
-        if (empty($parts)) {
-            return '';
-        }
-
-        $clause = ' WHERE';
-
-        $i = 0;
-        foreach ($parts as $part) {
-            if ($i > 0) {
-                $clause .= ' '.$part['operand'];
-            }
-            $clause .= ' '.$part['sql'];
-            $i++;
-        }
-
-        return $clause;
+        return $sql;
     }
 
     /**
@@ -867,9 +846,7 @@ class DatabaseSource extends AbstractSource implements
             return '';
         }
 
-        $clause = ' ORDER BY '.implode(', ', $parts);
-
-        return $clause;
+        return ' ORDER BY '.implode(', ', $parts);
     }
 
     /**

--- a/src/Charcoal/Source/FilterInterface.php
+++ b/src/Charcoal/Source/FilterInterface.php
@@ -57,20 +57,4 @@ interface FilterInterface extends
      * @return string
      */
     public function func();
-
-    /**
-     * Set the operator used for joining the next filter.
-     *
-     * @param  string $operand The logical operator.
-     * @throws InvalidArgumentException If the parameter is not a valid operand.
-     * @return FilterInterface Returns the current expression.
-     */
-    public function setOperand($operand);
-
-    /**
-     * Retrieve the operator used for joining the next filter.
-     *
-     * @return string
-     */
-    public function operand();
 }

--- a/src/Charcoal/Source/ModelAwareInterface.php
+++ b/src/Charcoal/Source/ModelAwareInterface.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Charcoal\Source;
+
+// From 'charcoal-core'
+use Charcoal\Model\ModelInterface;
+
+/**
+ * Describes awareness for an object model.
+ */
+interface ModelAwareInterface
+{
+    /**
+     * Set the source's model.
+     *
+     * @param ModelInterface $model The source's model.
+     * @return AbstractSource Chainable
+     */
+    public function setModel(ModelInterface $model);
+
+    /**
+     * Retrieve the source's model.
+     *
+     * @throws \Exception If not model was previously set.
+     * @return ModelInterface
+     */
+    public function model();
+
+    /**
+     * Determine if the source has a model.
+     *
+     * @return boolean
+     */
+    public function hasModel();
+}

--- a/src/Charcoal/Source/ModelAwareTrait.php
+++ b/src/Charcoal/Source/ModelAwareTrait.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Charcoal\Source;
+
+use RuntimeException;
+
+// From 'charcoal-core'
+use Charcoal\Model\ModelInterface;
+
+/**
+ * Provides awareness for an object model.
+ */
+trait ModelAwareTrait
+{
+    /**
+     * The source's object model.
+     *
+     * @var ModelInterface
+     */
+    private $model;
+
+    /**
+     * Set the source's model.
+     *
+     * @param ModelInterface $model The source's model.
+     * @return AbstractSource Chainable
+     */
+    public function setModel(ModelInterface $model)
+    {
+        $this->model = $model;
+        return $this;
+    }
+
+    /**
+     * Retrieve the source's model.
+     *
+     * @throws RuntimeException If not model was previously set.
+     * @return ModelInterface
+     */
+    public function model()
+    {
+        if ($this->model === null) {
+            throw new RuntimeException(
+                'Model is missing for source.'
+            );
+        }
+        return $this->model;
+    }
+
+    /**
+     * Determine if the source has a model.
+     *
+     * @return boolean
+     */
+    public function hasModel()
+    {
+        return ($this->model !== null);
+    }
+}

--- a/src/Charcoal/Source/SourceInterface.php
+++ b/src/Charcoal/Source/SourceInterface.php
@@ -3,10 +3,10 @@
 namespace Charcoal\Source;
 
 // From 'charcoal-core'
-use Charcoal\Model\ModelInterface;
 use Charcoal\Source\FilterCollectionInterface;
 use Charcoal\Source\OrderCollectionInterface;
 use Charcoal\Source\PaginationInterface;
+use Charcoal\Source\ModelAwareInterface;
 use Charcoal\Source\StorableInterface;
 
 /**
@@ -14,31 +14,9 @@ use Charcoal\Source\StorableInterface;
  */
 interface SourceInterface extends
     FilterCollectionInterface,
-    OrderCollectionInterface
+    OrderCollectionInterface,
+    ModelAwareInterface
 {
-    /**
-     * Set the source's Model.
-     *
-     * @param  ModelInterface $model The source's model.
-     * @return SourceInterface Returns the current source.
-     */
-    public function setModel(ModelInterface $model);
-
-    /**
-     * Determine if a model is assigned.
-     *
-     * @return boolean
-     */
-    public function hasModel();
-
-    /**
-     * Return the source's Model.
-     *
-     * @throws RuntimeException If not model was previously set.
-     * @return ModelInterface
-     */
-    public function model();
-
     /**
      * Set the properties of the source to fetch.
      *

--- a/tests/Charcoal/Source/AbstractSourceTest.php
+++ b/tests/Charcoal/Source/AbstractSourceTest.php
@@ -392,6 +392,7 @@ class AbstractSourceTest extends \PHPUnit_Framework_TestCase
      * 1. Instance of {@see ExpressionInterface}
      * 2. Instance of {@see Filter}
      *
+     * @see    \Charcoal\Tests\Source\FilterTest::testCreateFilter
      * @covers \Charcoal\Source\AbstractSource::createFilter
      */
     public function testCreateFilter()


### PR DESCRIPTION
Adds support for nesting `Filter` expressions; replaces #4.

**Requirements**
- locomotivemtl/charcoal-core#5

**Breaking Changes**
- See #5
- `Filter`
  - Renamed `DEFAULT_OPERAND` to `DEFAULT_CONJUNCTION`
  - Renamed `operand` to `conjunction`

**Highlights**
- `Filter`
  - Implements `FilterCollection` mixin
  - Added `!` and `NOT` operators
- `DatabaseFilter`
  - Compiles nested expressions
  - Added support for negating a custom condition or collection of filters using logical NOT operators
- `AbstractSource`
  - Implements new `ModelAware` mixin
- `DatabaseSource`
  - Compiles Filters using a master `DatabaseFilter` instance

**Example**
JSON Input:
```json
"filters": [
	"title LIKE 'Hello %'",
	{
		"conjunction": "OR",
		"filters": [
			{
				"property": "published",
				"value": true
			},
			{
				"property": "posted",
				"operator": "<",
				"value": "2017-11-16"
			}
		]
	},
	{
		"operator": "NOT",
		"filters": [
			{
				"property": "title",
				"value": "Hello World"
			},
			{
				"property": "modified",
				"operator": "IS NULL"
			}
		]
	}
]
```
SQL Output:
```sql
(title LIKE 'Hello %' AND (objTable.`published` = '1' OR objTable.`posted` < '2017-11-16') AND NOT (objTable.`title` = 'Hello World' AND objTable.`modified` IS NULL))
```