### PR TITLE
Fix Model/Property Validation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "prefer-stable": true,
     "extra": {
         "branch-alias": {
-            "dev-master": "0.4.x-dev"
+            "dev-master": "0.5.x-dev"
         }
     },
     "require": {
@@ -32,7 +32,7 @@
         "locomotivemtl/charcoal-cache": "~0.1",
         "locomotivemtl/charcoal-config": "~0.9",
         "locomotivemtl/charcoal-factory": "~0.4",
-        "locomotivemtl/charcoal-property": "~0.7",
+        "locomotivemtl/charcoal-property": "~0.9",
         "locomotivemtl/charcoal-view": "~0.3"
     },
     "require-dev": {

--- a/src/Charcoal/Model/ModelValidator.php
+++ b/src/Charcoal/Model/ModelValidator.php
@@ -4,9 +4,10 @@ namespace Charcoal\Model;
 
 // From 'charcoal-core'
 use Charcoal\Validator\AbstractValidator;
+use Charcoal\Validator\ValidatableInterface;
 
 /**
- *
+ * Model Validator
  */
 class ModelValidator extends AbstractValidator
 {
@@ -15,23 +16,27 @@ class ModelValidator extends AbstractValidator
      */
     public function validate()
     {
-        $model = $this->model;
+        $result = true;
 
+        $model = $this->model;
         $props = $model->properties();
 
-        $ret = true;
-        foreach ($props as $ident => $p) {
-            if (!$p ||  !$p->active()) {
+        foreach ($props as $ident => $prop) {
+            if (!($prop instanceof ValidatableInterface) || !$prop['active']) {
                 continue;
             }
-            $valid = $p->validate();
-            if ($valid === false) {
-                $validator = $p->validator();
+
+            $value   = $model->propertyValue($ident);
+            $isValid = $prop->setVal($value)->validate();
+            $prop->clearVal();
+
+            if ($isValid === false) {
+                $validator = $prop->validator();
                 $this->merge($validator, $ident);
-                $ret = false;
+                $result = false;
             }
         }
 
-        return $ret;
+        return $result;
     }
 }

--- a/src/Charcoal/Validator/ValidatorInterface.php
+++ b/src/Charcoal/Validator/ValidatorInterface.php
@@ -7,6 +7,10 @@ namespace Charcoal\Validator;
  */
 interface ValidatorInterface
 {
+    const ERROR   = 'error';
+    const WARNING = 'warning';
+    const NOTICE  = 'notice';
+
     /**
      * @param string $msg The error message.
      * @return self

--- a/tests/Charcoal/Model/ModelValidatorTest.php
+++ b/tests/Charcoal/Model/ModelValidatorTest.php
@@ -57,7 +57,13 @@ class ModelValidatorTest extends AbstractTestCase
             ]
         ]);
 
-        $obj = new ModelValidator($model);
-        $this->assertTrue($obj->validate());
+        $validator = new ModelValidator($model);
+        $this->assertFalse($validator->validate());
+
+        $model['foo'] = 'qux';
+        $this->assertFalse($validator->validate());
+
+        $model['foo'] = 'xyzzy';
+        $this->assertTrue($validator->validate());
     }
 }


### PR DESCRIPTION
Related:
- locomotivemtl/charcoal-property#10
- locomotivemtl/charcoal-admin#31

---

Changed:
- Bumped branch-alias to 0.5
- Method signature for `AbstractValidator::merge()`
- Class `ModelValidator` to only validate validatable properties

Added:
- Method `AbstractValidator::camelize()` with static caching

Fixed:
- Camelizing of property validation methods
- PHP syntax typo in `AbstractValidator::merge()` method