### PR TITLE
FilterCollectionTrait - hasActiveFilters method

### DIFF
--- a/src/Charcoal/Source/DatabaseSource.php
+++ b/src/Charcoal/Source/DatabaseSource.php
@@ -925,7 +925,7 @@ class DatabaseSource extends AbstractSource implements
         }
 
         $criteria = $this->createFilter([
-            'filters' => array_filter($this->filters(), function($filter) {
+            'filters' => array_filter($this->filters(), function ($filter) {
                 // Check for active subfilters
                 if ($filter->hasFilters()) {
                     return $filter->hasActiveFilters();

--- a/src/Charcoal/Source/DatabaseSource.php
+++ b/src/Charcoal/Source/DatabaseSource.php
@@ -925,7 +925,13 @@ class DatabaseSource extends AbstractSource implements
         }
 
         $criteria = $this->createFilter([
-            'filters' => $this->filters()
+            'filters' => array_filter($this->filters(), function($filter) {
+                // Check for active subfilters
+                if ($filter->hasFilters()) {
+                    return $filter->hasActiveFilters();
+                }
+                return true;
+            })
         ]);
 
         $sql = $criteria->sql();

--- a/src/Charcoal/Source/FilterCollectionTrait.php
+++ b/src/Charcoal/Source/FilterCollectionTrait.php
@@ -167,4 +167,28 @@ trait FilterCollectionTrait
      * @return FilterInterface A new filter expression object.
      */
     abstract protected function createFilter(array $data = null);
+
+    /**
+     * Determine if the object has any active subfilters (recursive)
+
+     * @return boolean
+     */
+    public function hasActiveFilters()
+    {
+        $endFilters = [];
+
+        // Recusively find filters with no subfilters
+        $this->traverseFilters(function($filter) use (&$endFilters) {
+            if (!$filter->hasFilters()) {
+                $endFilters[] = $filter;
+            }
+        });
+
+        // Exclude filters that aren't active
+        $endFilters = array_filter($endFilters, function ($filter) {
+            return $filter->active();
+        });
+
+        return !empty($endFilters);
+    }
 }

--- a/src/Charcoal/Source/FilterCollectionTrait.php
+++ b/src/Charcoal/Source/FilterCollectionTrait.php
@@ -170,7 +170,7 @@ trait FilterCollectionTrait
 
     /**
      * Determine if the object has any active subfilters (recursive)
-
+     *
      * @return boolean
      */
     public function hasActiveFilters()

--- a/src/Charcoal/Source/FilterCollectionTrait.php
+++ b/src/Charcoal/Source/FilterCollectionTrait.php
@@ -128,6 +128,30 @@ trait FilterCollectionTrait
     }
 
     /**
+     * Determine recursively if the object has any active subfilters.
+     *
+     * @return boolean
+     */
+    public function hasActiveFilters()
+    {
+        $endFilters = [];
+
+        // Recusively find filters with no subfilters
+        $this->traverseFilters(function ($filter) use (&$endFilters) {
+            if (!$filter->hasFilters()) {
+                $endFilters[] = $filter;
+            }
+        });
+
+        // Exclude filters that aren't active
+        $endFilters = array_filter($endFilters, function ($filter) {
+            return $filter->active();
+        });
+
+        return !empty($endFilters);
+    }
+
+    /**
      * Retrieve the query filters stored in this object.
      *
      * @return array
@@ -167,28 +191,4 @@ trait FilterCollectionTrait
      * @return FilterInterface A new filter expression object.
      */
     abstract protected function createFilter(array $data = null);
-
-    /**
-     * Determine if the object has any active subfilters (recursive)
-     *
-     * @return boolean
-     */
-    public function hasActiveFilters()
-    {
-        $endFilters = [];
-
-        // Recusively find filters with no subfilters
-        $this->traverseFilters(function($filter) use (&$endFilters) {
-            if (!$filter->hasFilters()) {
-                $endFilters[] = $filter;
-            }
-        });
-
-        // Exclude filters that aren't active
-        $endFilters = array_filter($endFilters, function ($filter) {
-            return $filter->active();
-        });
-
-        return !empty($endFilters);
-    }
 }

--- a/tests/Charcoal/Source/FilterCollectionTraitTest.php
+++ b/tests/Charcoal/Source/FilterCollectionTraitTest.php
@@ -120,6 +120,47 @@ class FilterCollectionTraitTest extends AbstractTestCase
     }
 
     /**
+     * Test collection for active filters.
+     *
+     * Assertions:
+     * 1. Empty; Default state
+     * 2. Populated; Mutated state
+     * 3. Populated; Added a inactive subfilter
+     *
+     * @covers \Charcoal\Source\FilterCollectionTrait::hasActiveFilters
+     *
+     * @return void
+     */
+    public function testHasActiveExpressions()
+    {
+        $obj = $this->createCollector();
+
+        /** 1. Default state */
+        $this->assertFalse($obj->hasActiveFilters());
+
+        /** 2. Mutated state */
+        $obj->addFilter([
+            'condition' => '( 1 + 1 = 2 )',
+            'filters' => $this->dummyItems,
+        ]);
+
+        $this->assertTrue($obj->hasActiveFilters());
+
+        /** 3. Added a inactive subfilter */
+        $obj->setFilters([[
+            'condition' => '( 1 + 1 = 2 )',
+            'filters' => [
+                [
+                    'condition' => '( 1 + 1 = 2 )',
+                    'active' => false,
+                ]
+            ]
+        ]]);
+
+        $this->assertFalse($obj->hasActiveFilters());
+    }
+
+    /**
      * Test the mass assignment of expressions.
      *
      * Assertions:


### PR DESCRIPTION
Adds a method that determines if the object (using FilterCollectionTrait) has any active subfilters (recursively)

This is used within `DatabaseSource->sqlFilters()` in order to exclude filters that don't contain any 'active' filters.